### PR TITLE
Add missing variable declaration

### DIFF
--- a/dynamic-ruler.el
+++ b/dynamic-ruler.el
@@ -306,7 +306,8 @@ in the buffer."
         (loc (count-lines (window-start) (point)))
         overlay-list
         this-overlay
-        buffer-file-name)
+        buffer-file-name
+        key)
     (goto-char (window-start))
     ;; although we now use overlays, temporary-invisible-change is still
     ;; needed because move-to-column can insert spaces into the buffer.


### PR DESCRIPTION
You can get this by byte-compile. (I got following byte-compile warnings)

```
In dynamic-ruler-momentary-column:
dynamic-ruler.el:338:5:Warning: assignment to free variable `key'
dynamic-ruler.el:336:11:Warning: reference to free variable `key'
```
